### PR TITLE
Fixed missing quotes for jquery.editable path

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -35,7 +35,7 @@
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
     <script src="{{ asset('bundles/liiptranslation/js/jquery.jeditable.js') }}"></script>
     <script type="text/javascript">
-        $('.translation-value').editable({{ path('liip_translation_inline_edit') }}, {
+        $('.translation-value').editable('{{ path('liip_translation_inline_edit') }}', {
             indicator: 'Saving...',
             tooltip: 'Click to edit...',
             submit: 'Ok',


### PR DESCRIPTION
Prefixing the bundle's routes leads to an JS error with the generated path `/foobar/inline-edit` as the browser thinks it's a regex. Adding ticks fixes this issue.

... and GH added a newline.
