### PR TITLE
adjust service definitions to work with symfony 2.6

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,7 +5,7 @@ services:
 
     liip.translation.repository:
         class: Liip\TranslationBundle\Repository\UnitRepository
-        arguments: ["%liip_translation_config%", "@translator", "@liip.translation.persistence", "@liip.translation.security"]
+        arguments: ["%liip_translation_config%", "@liip.translation.translator", "@liip.translation.persistence", "@liip.translation.security"]
 
     liip.translation.security:
         class: Liip\TranslationBundle\Security\Security
@@ -21,11 +21,11 @@ services:
 
     liip.translation.session_importer:
         class: Liip\TranslationBundle\Import\SessionImporter
-        arguments: ["@liip.translation.repository", "@session", "@translator"]
+        arguments: ["@liip.translation.repository", "@session", "@liip.translation.translator"]
 
     liip.translation.symfony_importer:
         class: Liip\TranslationBundle\Import\SymfonyImporter
-        arguments: ["%liip_translation_config%", "@translator", "@liip.translation.repository"]
+        arguments: ["%liip_translation_config%", "@liip.translation.translator", "@liip.translation.repository"]
 
     liip.translation.exporter:
         class: Liip\TranslationBundle\Export\ZipExporter


### PR DESCRIPTION
it seems we do not have functional tests that reveal this problem, but the reason for this is that https://github.com/symfony/symfony/commit/b7770bcfd0ca9341aeada2bc003d505fa95236f8 added https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggingTranslatorPass.php which decorates the default `translator` with the LoggingTranslator.

as we do not want just any translator alias injected, but the translator of this bundle, we should be explicit in the service definition. unless people where messing with the `translator` alias, this change is BC.